### PR TITLE
Beginning of eth_getBlockByNumber

### DIFF
--- a/dto/block.go
+++ b/dto/block.go
@@ -1,0 +1,56 @@
+/********************************************************************************
+   This file is part of go-web3.
+   go-web3 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   go-web3 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with go-web3.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************************/
+
+/**
+ * @file block.go
+ * @authors:
+ *   Jérôme Laurens <jeromelaurens@gmail.com>
+ * @date 2017
+ */
+
+package dto
+
+import (
+	// "encoding/json"
+	// "fmt"
+	// "strconv"
+
+	"github.com/regcostajr/go-web3/complex/types"
+)
+
+type Block struct {
+	Number     types.ComplexIntResponse `json:"number"`
+	Hash       string                   `json:"hash"`
+	ParentHash string                   `json:"parentHash"`
+	Nonce      types.ComplexIntResponse `json:"nonce"`
+	Timestamp  types.ComplexIntResponse `json:"timestamp"`
+}
+
+// func (block *Block) UnmarshalJSON(d []byte) error {
+// 	fmt.Println("Inside block.UnmarshalJSON")
+// 	type T2 Block // create new type with same structure as BLock but without its method set!
+// 	x := struct {
+// 		T2               // embed
+// 		Timestamp string `json:"timestamp"`
+// 	}{T2: T2(*block)} // don't forget this, if you do and 't' already has some fields set you would lose them
+
+// 	if err := json.Unmarshal(d, &x); err != nil {
+// 		return err
+// 	}
+// 	*block = Block(x.T2)
+// 	var err error = nil
+// 	block.Timestamp, err = strconv.ParseInt(x.Timestamp, 0, 64)
+// 	fmt.Printf("Timestamp en string %v, en int : %v", x.Timestamp, block.Timestamp)
+// 	return err
+// }

--- a/dto/request-result.go
+++ b/dto/request-result.go
@@ -183,6 +183,32 @@ func (pointer *RequestResult) ToTransactionReceipt() (*TransactionReceipt, error
 
 }
 
+func (pointer *RequestResult) ToBlock() (*Block, error) {
+
+	if pointer.Error != nil {
+		return nil, errors.New(pointer.Error.Message)
+	}
+
+	result := (pointer).Result.(map[string]interface{})
+
+	if len(result) == 0 {
+		return nil, customerror.EMPTYRESPONSE
+	}
+
+	block := &Block{}
+
+	marshal, err := json.Marshal(result)
+
+	if err != nil {
+		return nil, customerror.UNPARSEABLEINTERFACE
+	}
+
+	err = json.Unmarshal([]byte(marshal), block)
+
+	return block, err
+
+}
+
 func (pointer *RequestResult) ToSyncingResponse() (*SyncingResponse, error) {
 
 	if pointer.Error != nil {

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -25,6 +25,7 @@ import (
 	"github.com/regcostajr/go-web3/complex/types"
 	"github.com/regcostajr/go-web3/dto"
 	"github.com/regcostajr/go-web3/providers"
+	"strconv"
 )
 
 // Eth - The Eth Module
@@ -404,5 +405,30 @@ func (eth *Eth) GetTransactionReceipt(sourceCode string) (*dto.TransactionReceip
 	}
 
 	return pointer.ToTransactionReceipt()
+
+}
+
+// GetBlockByNumber - Returns the information about a block requested by number.
+// Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber
+// Parameters:
+//    - DATA, 32 Bytes - hash of a transaction
+// Returns:
+//    1. Object - A block object, or null when no transaction was found
+//    2. error
+func (eth *Eth) GetBlockByNumber(number int64, transactionDetails bool) (*dto.Block, error) {
+
+	params := make([]interface{}, 2)
+	params[0] = "0x" + strconv.FormatInt(number, 16)
+	params[1] = transactionDetails
+
+	pointer := &dto.RequestResult{}
+
+	err := eth.provider.SendRequest(pointer, "eth_getBlockByNumber", params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pointer.ToBlock()
 
 }

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -25,7 +25,6 @@ import (
 	"github.com/regcostajr/go-web3/complex/types"
 	"github.com/regcostajr/go-web3/dto"
 	"github.com/regcostajr/go-web3/providers"
-	"strconv"
 )
 
 // Eth - The Eth Module
@@ -411,14 +410,15 @@ func (eth *Eth) GetTransactionReceipt(sourceCode string) (*dto.TransactionReceip
 // GetBlockByNumber - Returns the information about a block requested by number.
 // Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber
 // Parameters:
-//    - DATA, 32 Bytes - hash of a transaction
+//    - number, QUANTITY - number of block
+//    - transactionDetails, bool - indicate if we should have or not the details of the transactions of the block
 // Returns:
 //    1. Object - A block object, or null when no transaction was found
 //    2. error
-func (eth *Eth) GetBlockByNumber(number int64, transactionDetails bool) (*dto.Block, error) {
+func (eth *Eth) GetBlockByNumber(number types.ComplexIntParameter, transactionDetails bool) (*dto.Block, error) {
 
 	params := make([]interface{}, 2)
-	params[0] = "0x" + strconv.FormatInt(number, 16)
+	params[0] = number.ToHex()
 	params[1] = transactionDetails
 
 	pointer := &dto.RequestResult{}

--- a/test/eth-getBlockByNumber_test.go
+++ b/test/eth-getBlockByNumber_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetBlockByNumber_IPCConnection(t *testing.T) {
+	err := Eth_GetBalance(IPCConnection())
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+}
+
+func TestGetBlockByNumber_HTTPConnection(t *testing.T) {
+	//previous block Dec-09-2017 10:28:29 AM +UTC
+	//Dec-09-2017 10:28:31 AM +UTC should be block 4701754, hash 0xaec14e98d578351a23d5ab40f65ee431063f582b5d736bbc0705a2eef0fb8f9d
+	//next block Dec-09-2017 10:28:55 AM +UTC
+	expectedBlockHash := "0xaec14e98d578351a23d5ab40f65ee431063f582b5d736bbc0705a2eef0fb8f9d"
+	var blockNumber int64 = 4701754
+
+	block, err := HTTPConnection().Eth.GetBlockByNumber(blockNumber, false)
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	if block == nil {
+		t.Error("Block returned is nil")
+		t.Fail()
+	}
+
+	actualBlockDate := time.Unix(block.Timestamp.ToInt64(), 0)
+	expectedBlockDate := time.Date(2017, 12, 9, 10, 28, 31, 0, time.UTC)
+
+	if strings.Compare(block.Hash, expectedBlockHash) != 0 {
+		t.Errorf("Expected block hash %v, got %v", expectedBlockHash, block.Hash)
+	}
+	if block.Number.ToInt64() != blockNumber {
+		t.Errorf("Expected block number %v, got %v", blockNumber, block.Number)
+	}
+	if actualBlockDate.Equal(expectedBlockDate) {
+		t.Errorf("Expected block date %v, got %v", expectedBlockDate, actualBlockDate)
+	}
+}

--- a/test/eth-getBlockByNumber_test.go
+++ b/test/eth-getBlockByNumber_test.go
@@ -1,26 +1,20 @@
 package test
 
 import (
+	"github.com/regcostajr/go-web3/complex/types"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestGetBlockByNumber_IPCConnection(t *testing.T) {
-	err := Eth_GetBalance(IPCConnection())
-
-	if err != nil {
-		t.Error(err)
-		t.Fail()
-	}
-}
+// TODO func TestGetBlockByNumber_IPCConnection(t *testing.T) {
 
 func TestGetBlockByNumber_HTTPConnection(t *testing.T) {
 	//previous block Dec-09-2017 10:28:29 AM +UTC
 	//Dec-09-2017 10:28:31 AM +UTC should be block 4701754, hash 0xaec14e98d578351a23d5ab40f65ee431063f582b5d736bbc0705a2eef0fb8f9d
 	//next block Dec-09-2017 10:28:55 AM +UTC
 	expectedBlockHash := "0xaec14e98d578351a23d5ab40f65ee431063f582b5d736bbc0705a2eef0fb8f9d"
-	var blockNumber int64 = 4701754
+	var blockNumber types.ComplexIntParameter = 4701754
 
 	block, err := HTTPConnection().Eth.GetBlockByNumber(blockNumber, false)
 
@@ -39,7 +33,7 @@ func TestGetBlockByNumber_HTTPConnection(t *testing.T) {
 	if strings.Compare(block.Hash, expectedBlockHash) != 0 {
 		t.Errorf("Expected block hash %v, got %v", expectedBlockHash, block.Hash)
 	}
-	if block.Number.ToInt64() != blockNumber {
+	if block.Number.ToInt64() != int64(blockNumber) {
 		t.Errorf("Expected block number %v, got %v", blockNumber, block.Number)
 	}
 	if actualBlockDate.Equal(expectedBlockDate) {

--- a/test/eth-getbalance_test.go
+++ b/test/eth-getbalance_test.go
@@ -5,11 +5,10 @@ import (
 
 	web3 "github.com/regcostajr/go-web3"
 	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/test"
 )
 
 func Eth_GetBalance(connection *web3.Web3) error {
-	accounts, err := test.ListAccounts(connection)
+	accounts, err := ListAccounts(connection)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi Reginaldo,
This a proposal of beginning for eth_getBlockByNumber
I let inside the code as comments of block.go another way to convert int64 in the form of 0xggggg to true int64.
This can be done through defining UnmarshalJSON and eventually MarshalJson of DTOs.
Sorry about the poor implementation of testGetBlockByNumber_IPCConnection : I don't have IPC connections, and I didn't checked these methods