### PR TITLE
Issue #20 Fix - Update `string` to `interface` to handle different object returns.

### DIFF
--- a/dto/request-result.go
+++ b/dto/request-result.go
@@ -41,9 +41,9 @@ type RequestResult struct {
 }
 
 type Error struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-	Data    string `json:"data"`
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
 }
 
 func (pointer *RequestResult) ToStringArray() ([]string, error) {


### PR DESCRIPTION
Fixing Issue #20 

Changed `string` to `interface{}` so that it can handle different objects returned. Can now handle the error return data from `ganache` and can now be displayed during testing in the when `ganache-cli` is used.

Now may need to handle error data with `Error.Data.(string)` in the case that a string is returned. 