### PR TITLE
Implement `GetTransactionByBlockHashAndIndex`

### DIFF
--- a/eth/eth.go
+++ b/eth/eth.go
@@ -346,10 +346,11 @@ func (eth *Eth) GetTransactionByBlockHashAndIndex(hash string, index types.Compl
 			return nil, errors.New("malformed block hash")
 		}
 	} else {
-		hash = "0x" + hash
-		if len(hash) != 62 {
+		if len(hash) != 64 {
 			return nil, errors.New("malformed block hash")
 		}
+
+		hash = "0x" + hash
 	}
 
 	params := make([]string, 2)
@@ -358,7 +359,7 @@ func (eth *Eth) GetTransactionByBlockHashAndIndex(hash string, index types.Compl
 
 	pointer := &dto.RequestResult{}
 
-	err := eth.provider.SendRequest(pointer, "eth_getTransactionByBlockNumberAndIndex", params)
+	err := eth.provider.SendRequest(pointer, "eth_getTransactionByBlockHashAndIndex", params)
 
 	if err != nil {
 		return nil, err

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -26,6 +26,8 @@ import (
 	"github.com/regcostajr/go-web3/dto"
 	"github.com/regcostajr/go-web3/eth/block"
 	"github.com/regcostajr/go-web3/providers"
+	"strings"
+	"errors"
 )
 
 // Eth - The Eth Module
@@ -318,9 +320,57 @@ func (eth *Eth) GetTransactionByHash(hash string) (*dto.TransactionResponse, err
 
 }
 
-// GetTransactionByBlockNumberAndIndex - Returns the information about a transaction requested by bloack index.
+// GetTransactionByBlockHashAndIndex - Returns the information about a transaction requested by block hash.
 // Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getTransactionByBlockNumberAndIndex
 // Parameters:
+//    - DATA, 32 Bytes - hash of a block
+//    - QUANTITY, number - index of the transaction position
+// Returns:
+//    1. Object - A transaction object, or null when no transaction was found
+//    - hash: DATA, 32 Bytes - hash of the transaction.
+//    - nonce: QUANTITY - the number of transactions made by the sender prior to this one.
+//    - blockHash: DATA, 32 Bytes - hash of the block where this transaction was in. null when its pending.
+//    - blockNumber: QUANTITY - block number where this transaction was in. null when its pending.
+//    - transactionIndex: QUANTITY - integer of the transactions index position in the block. null when its pending.
+//    - from: DATA, 20 Bytes - address of the sender.
+//    - to: DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.
+//    - value: QUANTITY - value transferred in Wei.
+//    - gasPrice: QUANTITY - gas price provided by the sender in Wei.
+//    - gas: QUANTITY - gas provided by the sender.
+//    - input: DATA - the data send along with the transaction.
+func (eth *Eth) GetTransactionByBlockHashAndIndex(hash string, index types.ComplexIntParameter) (*dto.TransactionResponse, error) {
+
+	// ensure that the hash is correctlyformatted
+	if strings.HasPrefix(hash, "0x") {
+		if len(hash) != 66 {
+			return nil, errors.New("malformed block hash")
+		}
+	} else {
+		hash = "0x" + hash
+		if len(hash) != 62 {
+			return nil, errors.New("malformed block hash")
+		}
+	}
+
+	params := make([]string, 2)
+	params[0] = hash
+	params[1] = index.ToHex()
+
+	pointer := &dto.RequestResult{}
+
+	err := eth.provider.SendRequest(pointer, "eth_getTransactionByBlockNumberAndIndex", params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pointer.ToTransactionResponse()
+}
+
+// GetTransactionByBlockNumberAndIndex - Returns the information about a transaction requested by block index.
+// Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getTransactionByBlockNumberAndIndex
+// Parameters:
+//    - QUANTITY, number - block number
 //    - DATA, 32 Bytes - hash of a transaction
 // Returns:
 //    1. Object - A transaction object, or null when no transaction was found

--- a/test/eth/eth-gettransactionbyblockhashandindex_test.go
+++ b/test/eth/eth-gettransactionbyblockhashandindex_test.go
@@ -24,10 +24,11 @@ import (
 "testing"
 
 "github.com/regcostajr/go-web3"
-"github.com/regcostajr/go-web3/complex/types"
 "github.com/regcostajr/go-web3/dto"
 "github.com/regcostajr/go-web3/providers"
 "math/big"
+    "time"
+    "github.com/regcostajr/go-web3/complex/types"
 )
 
 func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
@@ -59,39 +60,43 @@ func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
         t.FailNow()
     }
 
-    blockNumber, err := connection.Eth.GetBlockNumber()
-    num := types.ComplexIntParameter(blockNumber.ToInt64())
-    if err != nil {
-        t.Error(err)
-        t.Fail()
-    }
+    time.Sleep(time.Second)
 
-    block, err := connection.Eth.GetBlockByNumber(num, false)
-
-    if err != nil {
-        t.Error(err)
-        t.Fail()
-    }
-
-    index := types.ComplexIntParameter(0)
-    tx, err := connection.Eth.GetTransactionByBlockHashAndIndex(block.Hash, index)
+    txFromHash, err := connection.Eth.GetTransactionByHash(txID)
 
     if err != nil {
         t.Error(err)
         t.FailNow()
     }
 
+    index := types.ComplexIntParameter(txFromHash.TransactionIndex.ToInt64())
+
+    tx, err := connection.Eth.GetTransactionByBlockHashAndIndex(txFromHash.BlockHash, index)
+
+    if err != nil {
+       t.Error(err)
+       t.FailNow()
+    }
+
+    if tx.From != coinbase || tx.To != coinbase || tx.Value.ToInt64() != txVal.Int64() || tx.Hash != txID {
+       t.Errorf("Incorrect transaction from hash and index")
+       t.FailNow()
+    }
+
+
+    // test removing the 0x
+
+    tx, err = connection.Eth.GetTransactionByBlockHashAndIndex(txFromHash.BlockHash[2:], index)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
 
     if tx.From != coinbase || tx.To != coinbase || tx.Value.ToInt64() != txVal.Int64() || tx.Hash != txID {
         t.Errorf("Incorrect transaction from hash and index")
         t.FailNow()
     }
 
-    t.Log("BLOCK", block.Hash)
-    t.Log("BLOCK", index)
-    t.Log("BLOCK", tx.Hash)
-    t.Log("BLOCK", tx.BlockHash)
-    t.Log("BLOCK", tx.BlockNumber)
-    t.Log("BLOCK", tx.TransactionIndex)
 
 }

--- a/test/eth/eth-gettransactionbyblockhashandindex_test.go
+++ b/test/eth/eth-gettransactionbyblockhashandindex_test.go
@@ -1,0 +1,97 @@
+/********************************************************************************
+   This file is part of go-web3.
+   go-web3 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   go-web3 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with go-web3.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************************/
+
+/**
+ * @file eth-sendtransaction_test.go
+ * @authors:
+ *      Sigma Prime <sigmaprime.io>
+ * @date 2018
+ */
+package test
+
+import (
+"testing"
+
+"github.com/regcostajr/go-web3"
+"github.com/regcostajr/go-web3/complex/types"
+"github.com/regcostajr/go-web3/dto"
+"github.com/regcostajr/go-web3/providers"
+"math/big"
+)
+
+func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
+
+    var connection = web3.NewWeb3(providers.NewHTTPProvider("127.0.0.1:8545", 10, false))
+
+    coinbase, err := connection.Eth.GetCoinbase()
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    txVal := big.NewInt(2000000)
+
+    transaction := new(dto.TransactionParameters)
+    transaction.From = coinbase
+    transaction.To = coinbase
+    //transaction.Value = big.NewInt(0).Mul(big.NewInt(500), big.NewInt(1E18))
+    transaction.Value = txVal
+    transaction.Gas = big.NewInt(40000)
+
+    txID, err := connection.Eth.SendTransaction(transaction)
+
+    t.Log("Tx Submitted: ", txID)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    blockNumber, err := connection.Eth.GetBlockNumber()
+    num := types.ComplexIntParameter(blockNumber.ToInt64())
+    if err != nil {
+        t.Error(err)
+        t.Fail()
+    }
+
+    block, err := connection.Eth.GetBlockByNumber(num, false)
+
+    if err != nil {
+        t.Error(err)
+        t.Fail()
+    }
+
+    index := types.ComplexIntParameter(0)
+    tx, err := connection.Eth.GetTransactionByBlockHashAndIndex(block.Hash, index)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+
+    if tx.From != coinbase || tx.To != coinbase || tx.Value.ToInt64() != txVal.Int64() || tx.Hash != txID {
+        t.Errorf("Incorrect transaction from hash and index")
+        t.FailNow()
+    }
+
+    t.Log("BLOCK", block.Hash)
+    t.Log("BLOCK", index)
+    t.Log("BLOCK", tx.Hash)
+    t.Log("BLOCK", tx.BlockHash)
+    t.Log("BLOCK", tx.BlockNumber)
+    t.Log("BLOCK", tx.TransactionIndex)
+
+}


### PR DESCRIPTION
Implement RPC call to `eth_GetTransactionByBlockHashAndIndex`

Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionbyblockhashandindex

``tx, err := connection.Eth.GetTransactionByBlockHashAndIndex(blockHash, index)``
