### PR TITLE
Implement `GetBlockTransactionCountByHash`

### DIFF
--- a/eth/eth.go
+++ b/eth/eth.go
@@ -26,6 +26,8 @@ import (
 	"github.com/regcostajr/go-web3/dto"
 	"github.com/regcostajr/go-web3/eth/block"
 	"github.com/regcostajr/go-web3/providers"
+	"strings"
+	"errors"
 )
 
 // Eth - The Eth Module
@@ -537,3 +539,34 @@ func (eth *Eth) GetBlockByNumber(number types.ComplexIntParameter, transactionDe
 
 }
 
+// GetBlockTransactionCountByHash
+// Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblocktransactioncountbyhash
+// Parameters:
+//    - DATA, 32 bytes - block hash
+// Returns:
+//    1. QUANTITY, number - number of transactions in the block
+//    2. error
+func (eth *Eth) GetBlockTransactionCountByHash(hash string) (types.ComplexIntResponse, error) {
+
+	// ensure that the hash is correctlyformatted
+	if strings.HasPrefix(hash, "0x") {
+		if len(hash) != 66 {
+			return types.ComplexIntResponse(0), errors.New("malformed block hash")
+		}
+	} else {
+		if len(hash) != 64 {
+			return types.ComplexIntResponse(0), errors.New("malformed block hash")
+		}
+		hash = "0x" + hash
+	}
+
+	pointer := &dto.RequestResult{}
+
+	err := eth.provider.SendRequest(pointer, "eth_getBlockTransactionCountByHash", []string{hash})
+
+	if err != nil {
+		return types.ComplexIntResponse(0), err
+	}
+
+	return pointer.ToComplexIntResponse()
+}

--- a/test/eth/eth-getblocktransactioncountbyhash_test.go
+++ b/test/eth/eth-getblocktransactioncountbyhash_test.go
@@ -1,0 +1,103 @@
+/********************************************************************************
+   This file is part of go-web3.
+   go-web3 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   go-web3 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with go-web3.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************************/
+
+/**
+ * @file eth-getblocktransactioncountbyhash_test.go
+ * @authors:
+ *   Sigma Prime <sigmaprime.io>
+ * @date 2018
+ */
+
+package test
+
+import (
+    "testing"
+    "math/big"
+    "time"
+    "github.com/regcostajr/go-web3"
+    "github.com/regcostajr/go-web3/complex/types"
+    "github.com/regcostajr/go-web3/dto"
+    "github.com/regcostajr/go-web3/providers"
+)
+
+func TestGetBlockTransactionCountByHash(t *testing.T) {
+
+    var connection = web3.NewWeb3(providers.NewHTTPProvider("127.0.0.1:8545", 10, false))
+
+    blockNumber, err := connection.Eth.GetBlockNumber()
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    block, err := connection.Eth.GetBlockByNumber(types.ComplexIntParameter(blockNumber.ToInt64()), false)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+
+    txCount, err := connection.Eth.GetBlockTransactionCountByHash(block.Hash)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    // submit a transaction, wait for the block and there should be 1 tx.
+    coinbase, err := connection.Eth.GetCoinbase()
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    transaction := new(dto.TransactionParameters)
+    transaction.From = coinbase
+    transaction.To = coinbase
+    transaction.Value = big.NewInt(200000)
+    transaction.Gas = big.NewInt(40000)
+
+    txID, err := connection.Eth.SendTransaction(transaction)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    time.Sleep(time.Second)
+
+    tx, err := connection.Eth.GetTransactionByHash(txID)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    txCount, err = connection.Eth.GetBlockTransactionCountByHash(tx.BlockHash)
+
+    if err != nil {
+        t.Error(err)
+        t.FailNow()
+    }
+
+    if txCount.ToInt64() != 1 {
+       t.Error("invalid block transaction count")
+       t.FailNow()
+    }
+
+}
+


### PR DESCRIPTION
Implement the RPC call to: `GetBlockTransactionCountByHash`

Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblocktransactioncountbyhash

Usage: ``txCount, err := connection.Eth.GetBlockTransactionCountByHash(block.Hash)``

:smile: 