### PR TITLE
remove redundant big-number conversions.

### DIFF
--- a/.idea/go-web3.iml
+++ b/.idea/go-web3.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/go-web3.iml" filepath="$PROJECT_DIR$/.idea/go-web3.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="b1979893-ffd1-4918-80c3-5c97e855cf2d" name="Default" comment="">
+      <change beforePath="$PROJECT_DIR$/.travis.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.travis.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/db/db.go" beforeDir="false" afterPath="$PROJECT_DIR$/db/db.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dto/block.go" beforeDir="false" afterPath="$PROJECT_DIR$/dto/block.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dto/request-result.go" beforeDir="false" afterPath="$PROJECT_DIR$/dto/request-result.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dto/syncing.go" beforeDir="false" afterPath="$PROJECT_DIR$/dto/syncing.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dto/transaction.go" beforeDir="false" afterPath="$PROJECT_DIR$/dto/transaction.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/eth/block/default-block-number.go" beforeDir="false" afterPath="$PROJECT_DIR$/eth/block/default-block-number.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/eth/contract.go" beforeDir="false" afterPath="$PROJECT_DIR$/eth/contract.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/eth/eth.go" beforeDir="false" afterPath="$PROJECT_DIR$/eth/eth.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/glide.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/glide.yaml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/net/net.go" beforeDir="false" afterPath="$PROJECT_DIR$/net/net.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/personal/personal.go" beforeDir="false" afterPath="$PROJECT_DIR$/personal/personal.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/providers/http-provider.go" beforeDir="false" afterPath="$PROJECT_DIR$/providers/http-provider.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/providers/ipc-provider.go" beforeDir="false" afterPath="$PROJECT_DIR$/providers/ipc-provider.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/providers/websocket-provider.go" beforeDir="false" afterPath="$PROJECT_DIR$/providers/websocket-provider.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/shh/shh.go" beforeDir="false" afterPath="$PROJECT_DIR$/shh/shh.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-blocknumber_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-blocknumber_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-coinbase_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-coinbase_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-contract_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-contract_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-estimategas_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-estimategas_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-gasprice_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-gasprice_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getbalance_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getbalance_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getblockbyhash_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getblockbyhash_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getblockbynumber_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getblockbynumber_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getblocktransactioncountbyhash_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getblocktransactioncountbyhash_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getblocktransactioncountbynumber_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getblocktransactioncountbynumber_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-gettransactionbyblockhashandindex_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-gettransactionbyblockhashandindex_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-gettransactionbyblocknumberandindex_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-gettransactionbyblocknumberandindex_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-gettransactionbyhash_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-gettransactionbyhash_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-gettransactioncount_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-gettransactioncount_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getunclecountbyblockhash_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getunclecountbyblockhash_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-getunclecountbyblocknumber_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-getunclecountbyblocknumber_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-hashrate_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-hashrate_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-mining_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-mining_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-protocolversion_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-protocolversion_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-sendtransaction_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-sendtransaction_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-signtransaction_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-signtransaction_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/eth/eth-syncing_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/eth/eth-syncing_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/net/net-getpeercount_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/net/net-getpeercount_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/net/net-listening_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/net/net-listening_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/net/net-version_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/net/net-version_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/personal/personal-listaccounts_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/personal/personal-listaccounts_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/personal/personal-newaccount_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/personal/personal-newaccount_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/personal/personal-sendtransaction_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/personal/personal-sendtransaction_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/personal/personal-unlockaccount_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/personal/personal-unlockaccount_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/providers/http-provider_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/providers/http-provider_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/providers/ipc-provider_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/providers/ipc-provider_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/providers/websocket-provider_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/providers/websocket-provider_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/utils/utils-sha3_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/utils/utils-sha3_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/web3/web3-clientVersion_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/test/web3/web3-clientVersion_test.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/utils/utils.go" beforeDir="false" afterPath="$PROJECT_DIR$/utils/utils.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/web3.go" beforeDir="false" afterPath="$PROJECT_DIR$/web3.go" afterDir="false" />
+    </list>
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf>
+      <file leaf-file-name="contract.go" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/eth/contract.go">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="425">
+              <caret line="25" column="12" lean-forward="true" selection-start-line="25" selection-start-column="12" selection-end-line="25" selection-end-column="12" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="FindInProjectRecents">
+    <findStrings>
+      <find>github.com/regcostajr/go-web3</find>
+    </findStrings>
+    <replaceStrings>
+      <replace>github.com/apexliu/go-web3</replace>
+    </replaceStrings>
+  </component>
+  <component name="GOROOT" path="/usr/local/opt/go/libexec" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/eth/contract.go" />
+      </list>
+    </option>
+  </component>
+  <component name="JsBuildToolGruntFileManager" detection-done="true" sorting="DEFINITION_ORDER" />
+  <component name="JsBuildToolPackageJson" detection-done="true" sorting="DEFINITION_ORDER" />
+  <component name="JsGulpfileManager">
+    <detection-done>true</detection-done>
+    <sorting>DEFINITION_ORDER</sorting>
+  </component>
+  <component name="NodePackageJsonFileManager">
+    <packageJsonPaths />
+  </component>
+  <component name="ProjectFrameBounds" extendedState="1">
+    <option name="x" value="40" />
+    <option name="y" value="23" />
+    <option name="width" value="1639" />
+    <option name="height" value="1027" />
+  </component>
+  <component name="ProjectView">
+    <navigator proportions="" version="1">
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="ProjectPane">
+        <subPane>
+          <expand>
+            <path>
+              <item name="go-web3" type="b2602c69:ProjectViewProjectNode" />
+              <item name="go-web3" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="go-web3" type="b2602c69:ProjectViewProjectNode" />
+              <item name="go-web3" type="462c0819:PsiDirectoryNode" />
+              <item name="eth" type="462c0819:PsiDirectoryNode" />
+            </path>
+          </expand>
+          <select />
+        </subPane>
+      </pane>
+      <pane id="Scope" />
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="go.gopath.indexing.explicitly.defined" value="true" />
+    <property name="go.sdk.automatically.set" value="true" />
+    <property name="go.vendoring.notification.had.been.shown" value="true" />
+    <property name="last_opened_file_path" value="$USER_HOME$" />
+    <property name="nodejs_interpreter_path.stuck_in_default_project" value="undefined stuck path" />
+    <property name="nodejs_npm_path_reset_for_default_project" value="true" />
+  </component>
+  <component name="RunDashboard">
+    <option name="ruleStates">
+      <list>
+        <RuleState>
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+        </RuleState>
+        <RuleState>
+          <option name="name" value="StatusDashboardGroupingRule" />
+        </RuleState>
+      </list>
+    </option>
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="40" y="23" width="1639" height="1027" extended-state="0" />
+    <editor active="true" />
+    <layout>
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.24984346" />
+      <window_info anchor="bottom" id="TODO" order="6" />
+      <window_info anchor="bottom" id="Event Log" side_tool="true" />
+      <window_info anchor="right" id="Database" />
+      <window_info anchor="bottom" id="Find" order="1" />
+      <window_info anchor="bottom" id="Database Changes" show_stripe_button="false" />
+      <window_info anchor="bottom" id="Run" order="2" />
+      <window_info anchor="bottom" id="Version Control" />
+      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
+      <window_info anchor="bottom" id="Terminal" />
+      <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
+      <window_info id="Favorites" side_tool="true" />
+      <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
+      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
+      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
+      <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
+      <window_info anchor="bottom" id="Message" order="0" />
+      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
+    </layout>
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="1" />
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/eth/contract.go">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="425">
+          <caret line="25" column="12" lean-forward="true" selection-start-line="25" selection-start-column="12" selection-end-line="25" selection-end-column="12" />
+        </state>
+      </provider>
+    </entry>
+  </component>
+</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
     - 1.8.x
     - 1.10.x
-go_import_path: github.com/regcostajr/go-web3
+go_import_path: github.com/apexliu/go-web3
 sudo: false
 before_install:
     - sudo apt-get install software-properties-common -y -qq

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ TODO List
 ### go get
 
 ```bash
-go get -u github.com/regcostajr/go-web3
+go get -u github.com/apexliu/go-web3
 ```
 
 ### glide
 
 ```bash
-glide get github.com/regcostajr/go-web3
+glide get github.com/apexliu/go-web3
 ```
 
 ### Requirements

--- a/db/db.go
+++ b/db/db.go
@@ -22,8 +22,8 @@
 package db
 
 import (
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // DB - The DB Module

--- a/dto/block.go
+++ b/dto/block.go
@@ -26,7 +26,7 @@ import (
 	// "fmt"
 	// "strconv"
 
-	"github.com/regcostajr/go-web3/complex/types"
+	"github.com/apexliu/go-web3/complex/types"
 )
 
 type Block struct {

--- a/dto/request-result.go
+++ b/dto/request-result.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/constants"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/constants"
 
 	"encoding/json"
 )

--- a/dto/syncing.go
+++ b/dto/syncing.go
@@ -21,7 +21,7 @@
 
 package dto
 
-import "github.com/regcostajr/go-web3/complex/types"
+import "github.com/apexliu/go-web3/complex/types"
 
 type SyncingResponse struct {
 	StartingBlock types.ComplexIntResponse `json:"startingBlock"`

--- a/dto/transaction.go
+++ b/dto/transaction.go
@@ -22,7 +22,7 @@
 package dto
 
 import (
-	"github.com/regcostajr/go-web3/complex/types"
+	"github.com/apexliu/go-web3/complex/types"
 	"math/big"
 )
 

--- a/eth/block/default-block-number.go
+++ b/eth/block/default-block-number.go
@@ -21,7 +21,7 @@
 
 package block
 
-import "github.com/regcostajr/go-web3/complex/types"
+import "github.com/apexliu/go-web3/complex/types"
 
 // NUMBER - An integer block number
 // Reference: https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter

--- a/eth/contract.go
+++ b/eth/contract.go
@@ -25,11 +25,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
 	"strings"
 
-	"github.com/regcostajr/go-web3/utils"
+	"github.com/apexliu/go-web3/utils"
 	"math/big"
 )
 

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -25,10 +25,10 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/eth/block"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // Eth - The Eth Module

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/regcostajr/go-web3
+package: github.com/apexliu/go-web3
 import:
 - package: golang.org/x/net
   subpackages:

--- a/net/net.go
+++ b/net/net.go
@@ -22,9 +22,9 @@
 package net
 
 import (
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // Net - The Net Module

--- a/personal/personal.go
+++ b/personal/personal.go
@@ -22,8 +22,8 @@
 package personal
 
 import (
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // Personal - The Personal Module

--- a/providers/http-provider.go
+++ b/providers/http-provider.go
@@ -30,7 +30,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/regcostajr/go-web3/providers/util"
+	"github.com/apexliu/go-web3/providers/util"
 )
 
 type HTTPProvider struct {

--- a/providers/ipc-provider.go
+++ b/providers/ipc-provider.go
@@ -29,7 +29,7 @@ import (
 
 	"log"
 
-	"github.com/regcostajr/go-web3/providers/util"
+	"github.com/apexliu/go-web3/providers/util"
 )
 
 type IPCProvider struct {

--- a/providers/websocket-provider.go
+++ b/providers/websocket-provider.go
@@ -24,9 +24,9 @@ package providers
 import (
 	"math/rand"
 
-	"github.com/regcostajr/go-web3/constants"
+	"github.com/apexliu/go-web3/constants"
 
-	"github.com/regcostajr/go-web3/providers/util"
+	"github.com/apexliu/go-web3/providers/util"
 	"golang.org/x/net/websocket"
 )
 

--- a/shh/shh.go
+++ b/shh/shh.go
@@ -22,9 +22,9 @@
 package shh
 
 import (
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // SHH - The Net Module

--- a/test/eth/eth-blocknumber_test.go
+++ b/test/eth/eth-blocknumber_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthBlockNumber(t *testing.T) {

--- a/test/eth/eth-coinbase_test.go
+++ b/test/eth/eth-coinbase_test.go
@@ -24,9 +24,9 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/eth/block"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthCoinbase(t *testing.T) {

--- a/test/eth/eth-contract_test.go
+++ b/test/eth/eth-contract_test.go
@@ -23,9 +23,9 @@ package test
 
 import (
 	"encoding/json"
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"io/ioutil"
 	"math/big"
 	"testing"

--- a/test/eth/eth-estimategas_test.go
+++ b/test/eth/eth-estimategas_test.go
@@ -24,9 +24,9 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 )
 

--- a/test/eth/eth-gasprice_test.go
+++ b/test/eth/eth-gasprice_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthGasPrice(t *testing.T) {

--- a/test/eth/eth-getbalance_test.go
+++ b/test/eth/eth-getbalance_test.go
@@ -24,9 +24,9 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/eth/block"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthGetBalance(t *testing.T) {

--- a/test/eth/eth-getblockbyhash_test.go
+++ b/test/eth/eth-getblockbyhash_test.go
@@ -24,9 +24,9 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthGetBlockByHash(t *testing.T) {

--- a/test/eth/eth-getblockbynumber_test.go
+++ b/test/eth/eth-getblockbynumber_test.go
@@ -24,9 +24,9 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthGetBlockByNumber(t *testing.T) {

--- a/test/eth/eth-getblocktransactioncountbyhash_test.go
+++ b/test/eth/eth-getblocktransactioncountbyhash_test.go
@@ -22,10 +22,10 @@
 package test
 
 import (
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 	"testing"
 	"time"

--- a/test/eth/eth-getblocktransactioncountbynumber_test.go
+++ b/test/eth/eth-getblocktransactioncountbynumber_test.go
@@ -26,11 +26,11 @@ import (
 	"testing"
 	"time"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/eth/block"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestGetBlockTransactionCountByNumber(t *testing.T) {

--- a/test/eth/eth-gettransactionbyblockhashandindex_test.go
+++ b/test/eth/eth-gettransactionbyblockhashandindex_test.go
@@ -23,10 +23,10 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 	"time"
 )

--- a/test/eth/eth-gettransactionbyblocknumberandindex_test.go
+++ b/test/eth/eth-gettransactionbyblocknumberandindex_test.go
@@ -23,10 +23,10 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 )
 

--- a/test/eth/eth-gettransactionbyhash_test.go
+++ b/test/eth/eth-gettransactionbyhash_test.go
@@ -21,9 +21,9 @@
 package test
 
 import (
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 	"testing"
 	"time"

--- a/test/eth/eth-gettransactioncount_test.go
+++ b/test/eth/eth-gettransactioncount_test.go
@@ -24,11 +24,11 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/eth/block"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/eth/block"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 	"time"
 )

--- a/test/eth/eth-getunclecountbyblockhash_test.go
+++ b/test/eth/eth-getunclecountbyblockhash_test.go
@@ -22,9 +22,9 @@
 package test
 
 import (
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/providers"
 	"testing"
 )
 

--- a/test/eth/eth-getunclecountbyblocknumber_test.go
+++ b/test/eth/eth-getunclecountbyblocknumber_test.go
@@ -22,9 +22,9 @@
 package test
 
 import (
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/providers"
 	"testing"
 )
 

--- a/test/eth/eth-hashrate_test.go
+++ b/test/eth/eth-hashrate_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthHashrate(t *testing.T) {

--- a/test/eth/eth-mining_test.go
+++ b/test/eth/eth-mining_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthMining(t *testing.T) {

--- a/test/eth/eth-protocolversion_test.go
+++ b/test/eth/eth-protocolversion_test.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthGetProtocolVersion(t *testing.T) {

--- a/test/eth/eth-sendtransaction_test.go
+++ b/test/eth/eth-sendtransaction_test.go
@@ -23,10 +23,10 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 )
 

--- a/test/eth/eth-signtransaction_test.go
+++ b/test/eth/eth-signtransaction_test.go
@@ -23,10 +23,10 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 )
 

--- a/test/eth/eth-syncing_test.go
+++ b/test/eth/eth-syncing_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestEthSyncing(t *testing.T) {

--- a/test/net/net-getpeercount_test.go
+++ b/test/net/net-getpeercount_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestNetPeerCount(t *testing.T) {

--- a/test/net/net-listening_test.go
+++ b/test/net/net-listening_test.go
@@ -25,8 +25,8 @@ import (
 	"errors"
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestNetListening(t *testing.T) {

--- a/test/net/net-version_test.go
+++ b/test/net/net-version_test.go
@@ -26,8 +26,8 @@ import (
 	"sort"
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestNetVersion(t *testing.T) {

--- a/test/personal/personal-listaccounts_test.go
+++ b/test/personal/personal-listaccounts_test.go
@@ -23,8 +23,8 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestPersonalListAccounts(t *testing.T) {

--- a/test/personal/personal-newaccount_test.go
+++ b/test/personal/personal-newaccount_test.go
@@ -23,8 +23,8 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestPersonalNewAccount(t *testing.T) {

--- a/test/personal/personal-sendtransaction_test.go
+++ b/test/personal/personal-sendtransaction_test.go
@@ -23,9 +23,9 @@ package test
 import (
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 	"math/big"
 )
 

--- a/test/personal/personal-unlockaccount_test.go
+++ b/test/personal/personal-unlockaccount_test.go
@@ -24,8 +24,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestPersonalUnlockAccount(t *testing.T) {

--- a/test/providers/http-provider_test.go
+++ b/test/providers/http-provider_test.go
@@ -23,8 +23,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func Test_HttpProvider(t *testing.T) {

--- a/test/providers/ipc-provider_test.go
+++ b/test/providers/ipc-provider_test.go
@@ -23,8 +23,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func Test_IPCProvider(t *testing.T) {

--- a/test/providers/websocket-provider_test.go
+++ b/test/providers/websocket-provider_test.go
@@ -23,8 +23,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func Test_WebSocketProvider(t *testing.T) {

--- a/test/utils/utils-sha3_test.go
+++ b/test/utils/utils-sha3_test.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestUtilsSha3(t *testing.T) {

--- a/test/web3/web3-clientVersion_test.go
+++ b/test/web3/web3-clientVersion_test.go
@@ -24,8 +24,8 @@ package test
 import (
 	"testing"
 
-	web3 "github.com/regcostajr/go-web3"
-	"github.com/regcostajr/go-web3/providers"
+	web3 "github.com/apexliu/go-web3"
+	"github.com/apexliu/go-web3/providers"
 )
 
 func TestWeb3ClientVersion(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,9 +22,9 @@
 package utils
 
 import (
-	"github.com/regcostajr/go-web3/complex/types"
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/providers"
+	"github.com/apexliu/go-web3/complex/types"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/providers"
 )
 
 // Utils - The Utils Module

--- a/web3.go
+++ b/web3.go
@@ -22,12 +22,12 @@
 package web3
 
 import (
-	"github.com/regcostajr/go-web3/dto"
-	"github.com/regcostajr/go-web3/eth"
-	"github.com/regcostajr/go-web3/net"
-	"github.com/regcostajr/go-web3/personal"
-	"github.com/regcostajr/go-web3/providers"
-	"github.com/regcostajr/go-web3/utils"
+	"github.com/apexliu/go-web3/dto"
+	"github.com/apexliu/go-web3/eth"
+	"github.com/apexliu/go-web3/net"
+	"github.com/apexliu/go-web3/personal"
+	"github.com/apexliu/go-web3/providers"
+	"github.com/apexliu/go-web3/utils"
 )
 
 // Coin - Ethereum value unity value


### PR DESCRIPTION
There are redundant conversions. for example, the big-number is 1, we want a string like '000001', bigVal.string() return string '1', and fmt.Sprintf() convert it to '31', the final result is '000031', that's not we want. Just remove fmt.Sprintf(), it will work again.